### PR TITLE
fix: installation commands on various environments

### DIFF
--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -50,28 +50,28 @@ export const getInstallCmd = async (components: string[], cwd: string) => {
   const componentStr = components.join(" ");
 
   if (packageManager === "bun") {
-    return `bunx shadcn-vue add ${componentStr} -c ${cwd}`;
+    return `bunx shadcn-vue add ${componentStr} -c "${cwd}"`;
   }
 
   if (packageManager === "pnpm") {
-    return `pnpm dlx shadcn-vue@latest add ${componentStr} -c ${cwd}`;
+    return `pnpm dlx shadcn-vue@latest add ${componentStr} -c "${cwd}"`;
   }
 
-  return `npx shadcn-vue@latest add ${componentStr} -c ${cwd}`;
+  return `npx shadcn-vue@latest add ${componentStr} -c "${cwd}"`;
 };
 
 export const getInitCmd = async (cwd: string) => {
   const packageManager = await detectPackageManager();
 
   if (packageManager === "bun") {
-    return `bunx shadcn-vue@latest init -c ${cwd}`;
+    return `bunx shadcn-vue@latest init -c "${cwd}"`;
   }
 
   if (packageManager === "pnpm") {
-    return `pnpm dlx shadcn-vue@latest init -c ${cwd}`;
+    return `pnpm dlx shadcn-vue@latest init -c "${cwd}"`;
   }
 
-  return `npx shadcn-vue@latest init -c ${cwd}`;
+  return `npx shadcn-vue@latest init -c "${cwd}"`;
 };
 
 export const getComponentDocLink = (component: string) => {

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -120,7 +120,9 @@ export const getOrChooseCwd = async (): Promise<string> => {
       cwd = cwdFromConfig;
     }
 
-    return toShellPath(`${workspacePath}/${cwd}`);
+    const isAbsoluteCwd =
+      cwd.startsWith("/") || /^[a-z]:\//i.test(cwd) || cwd.startsWith("//");
+    return toShellPath(isAbsoluteCwd ? cwd : `${workspacePath}/${cwd}`);
   }
 
   const choice = await vscode.window.showQuickPick(

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -58,6 +58,40 @@ export const detectPackageManager = async (): Promise<PackageManager> => {
 };
 
 
+// Windows fsPath uses backslashes, which break in shells like Git Bash;
+// forward slashes work in every shell the command may run in.
+const toPosixPath = (p: string): string => p.replace(/\\/g, "/");
+
+// WSL cannot resolve Windows drive paths; it mounts them under /mnt/<drive>.
+const isWslDefaultTerminal = (): boolean => {
+  if (process.platform !== "win32") { return false; }
+
+  const config = vscode.workspace.getConfiguration("terminal.integrated");
+  const profileName = config.get<string>("defaultProfile.windows") ?? "";
+
+  if (/wsl/i.test(profileName)) { return true; }
+
+  const profiles =
+    config.get<Record<string, { source?: string; path?: string | string[] }>>(
+      "profiles.windows"
+    ) ?? {};
+  const profile = profiles[profileName];
+
+  if (!profile) { return false; }
+  if (profile.source === "WSL") { return true; }
+
+  const paths = Array.isArray(profile.path) ? profile.path : [profile.path];
+  return paths.some((p) => /wsl(\.exe)?$/i.test(p ?? ""));
+};
+
+const toWslPath = (p: string): string =>
+  p.replace(/^([a-z]):\//i, (_, drive: string) => `/mnt/${drive.toLowerCase()}/`);
+
+const toShellPath = (p: string): string => {
+  const posixPath = toPosixPath(p);
+  return isWslDefaultTerminal() ? toWslPath(posixPath) : posixPath;
+};
+
 export const getOrChooseCwd = async (): Promise<string> => {
   let cwd = "";
   const prefix = "${workspaceFolder}/";
@@ -68,11 +102,13 @@ export const getOrChooseCwd = async (): Promise<string> => {
 
   if (!workspaceFolders.length) { return "./"; }
 
-  const workspacePath = workspaceFolders[0]?.uri.fsPath ?? "";
-  const cwdFromConfig = vscode.workspace
-    .getConfiguration()
-    .get<string>("terminal.integrated.cwd")
-    ?.trim();
+  const workspacePath = toPosixPath(workspaceFolders[0]?.uri.fsPath ?? "");
+  const cwdFromConfig = toPosixPath(
+    vscode.workspace
+      .getConfiguration()
+      .get<string>("terminal.integrated.cwd")
+      ?.trim() ?? ""
+  );
 
   if (cwdFromConfig) {
     if (cwdFromConfig.startsWith(prefix)) {
@@ -84,7 +120,7 @@ export const getOrChooseCwd = async (): Promise<string> => {
       cwd = cwdFromConfig;
     }
 
-    return `${workspacePath}/${cwd}`;
+    return toShellPath(`${workspacePath}/${cwd}`);
   }
 
   const choice = await vscode.window.showQuickPick(
@@ -93,5 +129,7 @@ export const getOrChooseCwd = async (): Promise<string> => {
 
   if (!choice) { return "./"; }
 
-  return workspaceFolders.find((f) => f.name === choice)?.uri.fsPath ?? "./";
+  return toShellPath(
+    workspaceFolders.find((f) => f.name === choice)?.uri.fsPath ?? "./"
+  );
 };


### PR DESCRIPTION
Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command generation so install/init commands now correctly quote workspace paths, reducing failures with spaces or special characters.
  * Normalized workspace and terminal paths for better shell compatibility, including Windows and WSL environments.
  * Ensured selected or computed workspace paths are converted into a shell-safe format before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->