### PR TITLE
fix: detect package manager from package.json before lock files

### DIFF
--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -32,7 +32,59 @@ export const getFileStat = async (fileName: string) => {
   }
 };
 
+const PM_FROM_PACKAGE_JSON: Record<string, PackageManager> = {
+  npm: "npm",
+  pnpm: "pnpm",
+  yarn: "yarn",
+  bun: "bun",
+};
+
+/**
+ * Read the workspace's package.json and extract the package manager name.
+ *
+ * Checks two fields (in priority order):
+ * 1. `packageManager` — Corepack standard, e.g. `"pnpm@10.25.0"`
+ * 2. `devEngines.packageManager.name` — npm v11+ enforcement field
+ *
+ * Returns null when neither field is present or the value is unrecognised.
+ */
+const detectPackageManagerFromPackageJson = async (): Promise<PackageManager | null> => {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) { return null; }
+
+  for (const workspaceFolder of workspaceFolders) {
+    const pkgUri = vscode.Uri.joinPath(workspaceFolder.uri, "package.json");
+    try {
+      const raw = await vscode.workspace.fs.readFile(pkgUri);
+      const pkg = JSON.parse(Buffer.from(raw).toString("utf-8"));
+
+      // 1. Corepack `packageManager` field: "pnpm@10.25.0+sha512.xxx"
+      if (typeof pkg.packageManager === "string") {
+        const name = pkg.packageManager.split("@")[0]?.toLowerCase();
+        if (name && name in PM_FROM_PACKAGE_JSON) {
+          return PM_FROM_PACKAGE_JSON[name];
+        }
+      }
+
+      // 2. `devEngines.packageManager.name` (npm v11+)
+      const devPmName = pkg.devEngines?.packageManager?.name?.toLowerCase();
+      if (devPmName && devPmName in PM_FROM_PACKAGE_JSON) {
+        return PM_FROM_PACKAGE_JSON[devPmName];
+      }
+    } catch {
+      // package.json missing or unparseable — try next folder
+    }
+  }
+
+  return null;
+};
+
 export const detectPackageManager = async (): Promise<PackageManager> => {
+  // 1. Authoritative source: package.json fields
+  const fromPkg = await detectPackageManagerFromPackageJson();
+  if (fromPkg) { return fromPkg; }
+
+  // 2. Lock-file fallback (original logic)
   const lockFiles = ["bun.lock", "bun.lockb"];
   const results = await Promise.all(
     lockFiles.map((file) =>

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -177,6 +177,34 @@ export const getOrChooseCwd = async (): Promise<string> => {
     return toShellPath(isAbsoluteCwd ? cwd : `${workspacePath}/${cwd}`);
   }
 
+  // Scan for components.json to support monorepo sub-packages
+  const componentsJsonFiles = await vscode.workspace.findFiles(
+    "**/components.json",
+    "**/node_modules/**",
+    20
+  );
+
+  if (componentsJsonFiles.length > 1) {
+    const items = componentsJsonFiles.map((f) => ({
+      label: vscode.workspace.asRelativePath(f, false),
+      uri: f,
+    }));
+    const picked = await vscode.window.showQuickPick(items, {
+      placeHolder: "Select the package containing components.json",
+    });
+    if (picked) {
+      const dir = vscode.Uri.joinPath(picked.uri, "..");
+      return toShellPath(toPosixPath(dir.fsPath));
+    }
+    return "./";
+  }
+
+  if (componentsJsonFiles.length === 1) {
+    const dir = vscode.Uri.joinPath(componentsJsonFiles[0], "..");
+    return toShellPath(toPosixPath(dir.fsPath));
+  }
+
+  // No components.json found — fall back to workspace picker
   const choice = await vscode.window.showQuickPick(
     workspaceFolders.map((f) => f.name)
   );


### PR DESCRIPTION
## Problem

Two issues when using the extension in real-world projects:

### 1. Package manager detection ignores `package.json`

`detectPackageManager` only checks lock files (`bun.lock`, `pnpm-lock.yaml`, `yarn.lock`) and falls through to `npm` when none exist. This causes `EBADDEVENGINES` errors for projects that declare their package manager in `package.json` but haven't generated a lock file yet.

For example, a project with `"devEngines": { "packageManager": { "name": "pnpm" } }` would get `npx shadcn-vue add ...` generated, which npm v11 blocks before shadcn-vue even starts.

### 2. `getOrChooseCwd` doesn't support monorepos

`getOrChooseCwd` always returns the VS Code workspace root. In monorepos where `components.json` lives in a sub-package (e.g. `apps/pkg-ui`), the generated command points `-c` to the wrong directory, causing "No Tailwind CSS configuration found" errors.

## Fix

### 1. Read `package.json` before lock files

Detection order is now:

1. `package.json` → `packageManager` field (Corepack standard, e.g. `"pnpm@10.25.0"`)
2. `package.json` → `devEngines.packageManager.name` (npm v11+ enforcement field)
3. Lock files (`bun.lock`, `pnpm-lock.yaml`, `yarn.lock`) — unchanged original logic
4. Fallback to `npm` — unchanged

### 2. Scan for `components.json` before falling back to workspace picker

- **Multiple `components.json` found** → show quick pick to let user choose the target package
- **One `components.json` found** → use its directory automatically
- **None found** → fall back to original workspace folder picker (unchanged)